### PR TITLE
Temp fix om bugs op Internet explorer te fixen.

### DIFF
--- a/src/scripts/directives/tink-stick-to-top-angular.js
+++ b/src/scripts/directives/tink-stick-to-top-angular.js
@@ -127,7 +127,7 @@
        */
        stickyCal();
 
-      if(scrollTop > value.top && (scrollTop < value.stop || value.stop === undefined)){
+      if(scrollTop > value.top.toFixed(2) && (scrollTop < value.stop || value.stop === undefined)){
         addSticky(value);
       }else{
         removeSticky(value);


### PR DESCRIPTION
IsSticky werd in internet explorer altijd op het element gezet omdat de value.top bijna 10 getallen achter de komma bevatte en zo een honderduizendste kleiner was dan scrollTop.